### PR TITLE
Enhancement of @satorijs/plugin-im (WIP)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,11 +39,13 @@
     }
   },
   "peerDependencies": {
+    "@cordisjs/plugin-webui": "^0.1.12",
     "minato": "^3.5.0"
   },
   "devDependencies": {
     "@cordisjs/client": "^0.1.12",
     "@cordisjs/plugin-server": "^0.2.3",
+    "@cordisjs/plugin-webui": "^0.1.12",
     "@satorijs/core": "^4.2.6",
     "@types/mime-types": "^2",
     "minato": "^3.5.0"
@@ -51,6 +53,7 @@
   "dependencies": {
     "@satorijs/core": "^4.2.6",
     "@satorijs/plugin-im-utils": "^0.0.0",
+    "cordis": "^3.18.1",
     "cosmokit": "^1.6.2",
     "mime-types": "^2.1.35"
   }


### PR DESCRIPTION
# Koishi IM
或称 Satori IM。下文简称为 IM。

## Plugins
* @satorijs/plugin-im
* @satorijs/plugin-im-utils

## Description

### API
`im.gateway` 服务中将 IM 的其他主要服务集成起来，为开发者提供了数个快速构建访问的方法。
```ts
declare module '@satorijs/plugin-im' {
    interface Apis {
        'foo': {
            name: string
            id: string
            $response: string
        }
    }
    interface Events {
        'foo-called': void
    }
}

ctx.im.middleware('foo', function (session, next) {
    if (!session.selfId) throw Error()
    
    return next()
})

ctx.im.listen('foo', async function (session) {
    return 'response of foo'
})

ctx.im.after('foo', function (session) {
    im.event.dispatch('foo-called', [getId()])
})
```

`Apis` 在类型系统上为请求体提供约束支持。其中的 `$response` 属性代表响应的数据类型。
可以使用 `Api` 类型来获得 IDE 的类型提示。
```ts
import { Api } from '@satorijs/plugin-im'

declare module '@satorijs/plugin-im' {
    interface Apis {
        'bar': Api<{name: string, $response: string}>
    }
}
```

`im.middleware()` 可以在请求的生命周期中注册中间件，其将返回一个 `Disposable` 来支持回收。
```ts
const dispose = ctx.im.middleware('foo', async (session) => {
    await validateFoo(session.data)

    return next()
})

ctx.im.middleware(['foo', 'bar'], async (session) => {
    await validateFooAndBar(session.data)

    return next()
})

ctx.im.middleware('*', (session) => {
    verifyToken(session.data.$access)

    return next()
}, true)

dispose()
```
中间件可作用于多个指定路由。
一般来说，中间件的调用顺序以其**注册顺序**决定，这意味着单个路由下的中间件优先级**允许高于全局中间件**。
第三个参数为 `prepend`，其支持了前置中间件的创建。

`im.after()` 支持在请求生命周期结束后触发其中回调，其可以用于日志记录，推送事件等，而不会阻碍请求的响应。

当这个接口注册后，在前端将如此调用：
```ts
send('im/bar', { $access: accessToken, name: 'bar'})
```

### 其他更新
* 修改了 `im.data` 的调用方式，内置了一些基础的 Dao 对象。如：
```ts
  ctx.im.data.guild(gid).members.list()

  ctx.im.data.guild.fetch(gid)

  ctx.im.data.guild.create(guildData)
```
* 优化了权限验证机制以及事件的主动推送机制，并将他们从 `im.data` 服务分离，让其成为纯粹的数据访问层。
* 优化了令牌机制，加入长期有效的 refreshToken 来用于刷新原先的临时 token。